### PR TITLE
prml_errata.tex: error on page xi

### DIFF
--- a/prml_errata.tex
+++ b/prml_errata.tex
@@ -77,6 +77,10 @@ which have also been included in this report for the reader's convenience.
 \section*{Corrections}
 \addcontentsline{toc}{section}{Corrections}
 
+\erratum{Page~xi}
+Paragraph~6, Line~1:
+$\left|f(x)/g(x)\right|$ should read $\left|g(x)/f(x)\right|$.
+
 \erratum{Page~5}
 Equation~(1.1):
 The lower ellipsis ($\ldots$) should be centered ($\cdots$).\footnote{%

--- a/prml_errata.tex
+++ b/prml_errata.tex
@@ -78,7 +78,7 @@ which have also been included in this report for the reader's convenience.
 \addcontentsline{toc}{section}{Corrections}
 
 \erratum{Page~xi}
-Paragraph~6, Line~1:
+Paragraph~\textminus2, Line~1:
 $\left|f(x)/g(x)\right|$ should read $\left|g(x)/f(x)\right|$.
 
 \erratum{Page~5}


### PR DESCRIPTION
Found an error on page xi in the definition of big-O notation (function names swapped).