### PR TITLE
Errata for Figures 5.11 and 7.1

### DIFF
--- a/prml_errata.tex
+++ b/prml_errata.tex
@@ -2347,6 +2347,15 @@ Paragraph~1, Line~\textminus1:
 The parameters rescaling should be
 $\lambda_1 \to a^2\lambda_1$ and $\lambda_2 \to c^{-2}\lambda_2$.
 
+\erratum{Page~260}
+% Due to Tommy (@tommyod)
+Figure~5.11:
+The subscripts of the last two alpha values should be 2, not 1, in every subplot.
+In other words, the values should be
+$\alpha_1^{\text{w}}$, $\alpha_1^{\text{b}}$, $\alpha_2^{\text{w}}$ and $\alpha_2^{\text{b}}$
+instead of 
+$\alpha_1^{\text{w}}$, $\alpha_1^{\text{b}}$, $\alpha_1^{\text{w}}$ and $\alpha_1^{\text{b}}$.
+
 \erratum{Page~266}
 % Due to Mark-Jan Nederhof
 The unlabeled equation following the line starting
@@ -2492,6 +2501,12 @@ Insert a comma (,) before the clause~``which breaks translation\dots''
 % Due to Mark-Jan Nederhof
 Paragraph~\textminus1, Line~\textminus3:
 Insert a comma (,) before the clause~``who consider a\dots''
+
+\erratum{Page~327}
+% Due to Tommy (@tommyod)
+Figure~7.1:
+The sign of $y$ is swapped in the sub-figures.
+The choice is arbitrary, but for consistency with Figure~7.3, the notation in the leftmost sub-figure is preferred.
 
 \erratum{Page~333}
 Equation~(7.29):


### PR DESCRIPTION
Found two more errata in figures. As always, feel free to edit the text before merging.

Also, on page 343 I believe there is a contradiction. Last sentence in the second to last paragraph states that "*at most vN data points fall outside the insensitive tube*", and that "*at least vN data points lie either on the tube or outside it*".